### PR TITLE
Initial work on capturing hard navigations

### DIFF
--- a/src/backend/opbeat_backend.js
+++ b/src/backend/opbeat_backend.js
@@ -1,5 +1,4 @@
 var backendUtils = require('./backend_utils')
-var captureHardNavigation = require('../performance/captureHardNavigation')
 var utils = require('../lib/utils')
 
 module.exports = OpbeatBackend
@@ -144,11 +143,6 @@ OpbeatBackend.prototype.sendTransactions = function (transactionList) {
   if (this._config.isValid()) {
     var browserResponsivenessInterval = opbeatBackend._config.get('performance.browserResponsivenessInterval')
     var checkBrowserResponsiveness = opbeatBackend._config.get('performance.checkBrowserResponsiveness')
-    var pageLoad = opbeatBackend._config.get('performance.pageLoad')
-
-    if (pageLoad) {
-      transactionList.forEach(captureHardNavigation);
-    }
 
     transactionList.forEach(function (transaction) {
       transaction.traces.sort(function (traceA, traceB) {
@@ -163,7 +157,7 @@ OpbeatBackend.prototype.sendTransactions = function (transactionList) {
     })
 
     var filterTransactions = transactionList.filter(function (tr) {
-      if (checkBrowserResponsiveness) {
+      if (checkBrowserResponsiveness && !tr.isHardNavigation) {
         var buffer = opbeatBackend._config.get('performance.browserResponsivenessBuffer')
 
         var duration = tr._rootTrace.duration()

--- a/src/backend/opbeat_backend.js
+++ b/src/backend/opbeat_backend.js
@@ -1,4 +1,5 @@
 var backendUtils = require('./backend_utils')
+var captureHardNavigation = require('../performance/captureHardNavigation')
 var utils = require('../lib/utils')
 
 module.exports = OpbeatBackend
@@ -143,6 +144,11 @@ OpbeatBackend.prototype.sendTransactions = function (transactionList) {
   if (this._config.isValid()) {
     var browserResponsivenessInterval = opbeatBackend._config.get('performance.browserResponsivenessInterval')
     var checkBrowserResponsiveness = opbeatBackend._config.get('performance.checkBrowserResponsiveness')
+    var pageLoad = opbeatBackend._config.get('performance.pageLoad')
+
+    if (pageLoad) {
+      transactionList.forEach(captureHardNavigation);
+    }
 
     transactionList.forEach(function (transaction) {
       transaction.traces.sort(function (traceA, traceB) {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -23,7 +23,8 @@ function Config () {
       similarTraceThreshold: 0.05,
       captureInteractions: false,
       sendVerboseDebugInfo: false,
-      includeXHRQueryString: false
+      includeXHRQueryString: false,
+      capturePageLoad: false
     },
     libraryPathPattern: '(node_modules|bower_components|webpack)',
     context: {},

--- a/src/performance/captureHardNavigation.js
+++ b/src/performance/captureHardNavigation.js
@@ -1,0 +1,62 @@
+var Trace = require('../transaction/trace')
+var utils = require('../lib/utils')
+var eventPairs = [
+  ['domainLookupStart', 'domainLookupEnd', 'DNS lookup'],
+  ['connectStart', 'connectEnd', 'Connect'],
+  ['requestStart', 'responseStart', 'Sending and waiting for first byte'],
+  ['responseStart', 'responseEnd', 'Downloading'],
+  ['domLoading', 'domInteractive', 'Fetching, parsing and sync. execution'],
+  ['domContentLoadedEventStart', 'domContentLoadedEventEnd', '"DOMContentLoaded" event handling'],
+  ['loadEventStart', 'loadEventEnd', '"load" event handling'],
+]
+
+module.exports = function captureHardNavigation (transaction) {
+  if (transaction.wasHardNavigation && window.performance && window.performance.timing) {
+    var baseTime = window.performance.timing.navigationStart
+    var timings = window.performance.timing
+
+    transaction._rootTrace._start = transaction._start = 0
+    transaction.type = 'page-load'
+    transaction.name += ' (initial page load)' // temporary until we support transaction types
+    for(var i = 0; i < eventPairs.length; i++) {
+      var transactionStart = eventPairs[0]
+      var start = timings[eventPairs[i][0]],
+          end = timings[eventPairs[i][1]]
+      if (start && end && end - start !== 0) {
+        var trace = new Trace(transaction, eventPairs[i][2], "hard-navigation.browser-timing")
+        trace._start = timings[eventPairs[i][0]] - baseTime
+        trace._end = timings[eventPairs[i][1]] - baseTime
+        trace.ended = true
+        trace.setParent(transaction._rootTrace)
+        trace.end()
+      }
+    }
+
+    if (window.performance.getEntriesByType) {
+      var entries = performance.getEntriesByType("resource")
+      for(var i = 0; i < entries.length; i++) {
+        var entry = entries[i]
+        if (entry.initiatorType && entry.initiatorType == 'xmlhttprequest')
+        {
+          continue
+        } else {
+          var kind = 'resource'
+          if (entry.initiatorType) {
+            kind += '.' + entry.initiatorType
+          }
+
+          var trace = new Trace(transaction, entry.name, kind)
+          trace._start = entry.startTime
+          trace._end = entry.responseEnd
+          trace.ended = true
+          trace.setParent(transaction._rootTrace)
+          trace.end()
+        }
+      }
+    }
+
+    transaction._adjustStartToEarliestTrace()
+    transaction._adjustEndToLatestTrace()
+  }
+  return 0
+}

--- a/src/performance/trace.js
+++ b/src/performance/trace.js
@@ -51,7 +51,7 @@ Trace.prototype.end = function () {
 }
 
 Trace.prototype.duration = function () {
-  if (!this.ended || !this._start) {
+  if (utils.isUndefined(this.ended) || utils.isUndefined(this._start)) {
     return null
   }
   this._diff = this._end - this._start

--- a/src/performance/transaction.js
+++ b/src/performance/transaction.js
@@ -43,6 +43,8 @@ var Transaction = function (name, type, options) {
 
   this.duration = this._rootTrace.duration.bind(this._rootTrace)
   this.nextId = 0
+
+  this.isHardNavigation = false
 }
 
 Transaction.prototype.debugLog = function () {

--- a/test/performance/transactionService.spec.js
+++ b/test/performance/transactionService.spec.js
@@ -159,4 +159,25 @@ describe('TransactionService', function () {
     zoneServiceMock.spec.onInvokeTask(task)
     expect(task.trace.ended).toBe(true)
   })
+
+  it('should capture page load on first transaction', function (done) {
+    config.set('performance.enable', true)
+    config.set('performance.capturePageLoad', true)
+    transactionService = new TransactionService(zoneServiceMock, logger, config)
+
+    var tr1 = transactionService.startTransaction('transaction1', 'transaction')
+    expect(tr1.isHardNavigation).toBe(false)
+    tr1.detectFinish()
+    tr1.donePromise.then(function () {
+      expect(tr1.isHardNavigation).toBe(true)
+    })
+
+    var tr2 = transactionService.startTransaction('transaction2', 'transaction')
+    expect(tr2.isHardNavigation).toBe(false)
+    tr2.detectFinish()
+    tr2.donePromise.then(function () {
+      expect(tr2.isHardNavigation).toBe(false)
+      done()
+    })
+  })
 })


### PR DESCRIPTION
Very rough initial page load code extracted from opbeat-react.

captureHardNavigation, it looks for a property `wasHardNavigation` on the transaction and will re-arrange the traces in the transaction with the traces it creates from the data from the browser apis.

Because only the first route change should be a hard navigation, you can use a simple global to ensure it only happens to one transaction. Something like this in your router:
```js
var didHardNavigation = false;

function didRouteChange(route, transaction) {
  if (!didHardNavigation) { 
    transactions.wasHardNavigation = true;
    didHardNavigation = true;
  }
}
```